### PR TITLE
Add ldap_group_admin_dn parameter

### DIFF
--- a/jobs/harbor/spec
+++ b/jobs/harbor/spec
@@ -132,6 +132,9 @@ properties:
   ldap.basedn:
     description: "The base DN from which to look up a user in LDAP/AD"
     default: "ou=people,dc=mydomain,dc=com"
+  ldap.group_admin_dn:
+    description: "The group DN from wich to look up an admin user in LDAP/AD"
+    default: ""
   ldap.uid:
     description: "The attribute used in a search to match a user, it could be uid, cn, email, sAMAccountName or other attributes."
     default: "uid"

--- a/jobs/harbor/templates/config/harbor.cfg
+++ b/jobs/harbor/templates/config/harbor.cfg
@@ -90,6 +90,9 @@ ldap_search_pwd = <%= searchpwd %>
 #The base DN from which to look up a user in LDAP/AD
 ldap_basedn = <%= p("ldap.basedn") %>
 
+#The base group DN from which to look up a admin in LDAP/AD
+ldap_group_admin_dn = <%= p("ldap.group_admin_dn") %)
+
 <% if_p("ldap.filter") do |filter| %>
 #Search filter for LDAP/AD, make sure the syntax of the filter is correct.
 ldap_filter = <%= filter %>


### PR DESCRIPTION
add ldap_group_admin_dn to be able to have admin user when use LDAP.
see issue  https://github.com/vmware/harbor-boshrelease/issues/45