### PR TITLE
Removing admin_password_for_smoketest to use admin_password

### DIFF
--- a/jobs/harbor/spec
+++ b/jobs/harbor/spec
@@ -33,7 +33,6 @@ provides:
   - hostname
   - ui_url_protocol
   - admin_password
-  - admin_password_for_smoketest
   - ssl.cert
   - ssl.key
   - ssl.ca

--- a/jobs/smoke-test/templates/run.sh
+++ b/jobs/smoke-test/templates/run.sh
@@ -112,8 +112,8 @@ docker -H $DOCKER_HOST load -i $BUSYBOX_PATH
 export APP_HOST_IP='<%= link('harbor_reference').instances[0].address %>'
 export HTTP_PROTOCOL='<%= link('harbor_reference').p('ui_url_protocol') %>'
 export TESTING_ENV_HOSTNAME='<%= link('harbor_reference').p('hostname') %>'
-export TESTING_ENV_ADMIN_PASS='<%= link('harbor_reference').p('admin_password_for_smoketest') %>'
-export TESTING_ENV_PASSWORD='<%= link('harbor_reference').p('admin_password_for_smoketest') %>'
+export TESTING_ENV_ADMIN_PASS='<%= link('harbor_reference').p('admin_password') %>'
+export TESTING_ENV_PASSWORD='<%= link('harbor_reference').p('admin_password') %>'
 export POPULATE_ETC_HOSTS='<%= link('harbor_reference').p('populate_etc_hosts') %>'
 export CA_FILE_PATH=$SMOKE_TEST_JOB_DIR/config/ca.crt
 export CERT_FILE_PATH=$SMOKE_TEST_JOB_DIR/config/cert.crt


### PR DESCRIPTION
Currently the deployment fails because the spec file is providing a variables it's not setting.
This PR removes that provides references and then modifies the smoke test to just use the admin password. 