### PR TITLE
Change the path of server cert

### DIFF
--- a/jobs/harbor/templates/config/harbor.yml
+++ b/jobs/harbor/templates/config/harbor.yml
@@ -15,8 +15,8 @@ https:
   # https port for harbor, default is 443
   port: 443
   #The path of cert and key files for nginx
-  certificate: /data/cert/server.crt
-  private_key: /data/cert/server.key
+  certificate: /var/vcap/jobs/harbor/config/server.crt
+  private_key: /var/vcap/jobs/harbor/config/server.key
 <%- end %>
 
 # Uncomment extearnal_url if you want to enable external proxy


### PR DESCRIPTION
Change the path of server cert, the Harbor prepare can not resolve a linked path. /data/cert/server.key