### PR TITLE
Fix registry_storage_provider.redirect check

### DIFF
--- a/jobs/harbor/templates/config/harbor.yml
+++ b/jobs/harbor/templates/config/harbor.yml
@@ -49,7 +49,7 @@ data_volume: /data
 #     maxthreads: 100
 
 storage_service:
-<%- if p("registry_storage_provider.redirect") == "true" %>
+<%- if p("registry_storage_provider.redirect") == true %>
   redirect:
     disabled: true
 <%- end %>


### PR DESCRIPTION
Instead of checking for the string `"true"`, check whether the statement
is `true`.