### PR TITLE
Change the location of trusted_certificate.crt to /tmp to avoid soft …

### DIFF
--- a/jobs/harbor/templates/bin/pre-start.erb.sh
+++ b/jobs/harbor/templates/bin/pre-start.erb.sh
@@ -87,7 +87,8 @@ function prepareCert() {
     cp ${HARBOR_JOB_DIR}/config/server.crt /tmp/
     cp ${HARBOR_JOB_DIR}/config/server.key /tmp/
     cp ${HARBOR_JOB_DIR}/config/uaa_ca.crt $HARBOR_DATA/cert/
-    cp ${HARBOR_JOB_DIR}/config/trusted_certificates.crt $HARBOR_DATA/cert/
+    cp ${HARBOR_JOB_DIR}/config/trusted_certificates.crt /tmp/
+    chmod 644 /tmp/trusted_certificates.crt
     chmod 644 $HARBOR_DATA/cert/*
 
     cp ${HARBOR_JOB_DIR}/config/ca.crt $HARBOR_DATA/ca_download
@@ -287,7 +288,7 @@ function updateVersionFile() {
 }
 
 function cleanCertFile(){
-  rm -rf /tmp/server.key /tmp/server.crt
+  rm -rf /tmp/server.key /tmp/server.crt /tmp/trusted_certificates.crt
 }
 
 # It might take long time to do in-container migrate, 

--- a/jobs/harbor/templates/config/harbor.yml
+++ b/jobs/harbor/templates/config/harbor.yml
@@ -56,7 +56,7 @@ data_volume: /data
 storage_service:
   redirect:
     disabled: <%= p("registry_storage_provider.s3.disable_redirect") %>  
-  ca_bundle: /data/cert/trusted_certificates.crt
+  ca_bundle: /tmp/trusted_certificates.crt
 <%- if p("registry_storage_provider.name") == "s3" %>
 # S3 storage
   s3:


### PR DESCRIPTION
The change the trusted_certificates.crt to /tmp/trusted_certificates.crt so that there is no soft link in path.

If there is a soft link in path, the prepare container cannot read/copy the file and cause the minio custom cert is not trusted by registry container.