### PR TITLE
Update default scanner before test

### DIFF
--- a/src/harbor-api-testing/client/harbor_api_client.go
+++ b/src/harbor-api-testing/client/harbor_api_client.go
@@ -167,6 +167,31 @@ func (ac *APIClient) Delete(url string) error {
 	return nil
 }
 
+// Patch data
+func (ac *APIClient) Patch(url string, data []byte) error {
+	if strings.TrimSpace(url) == "" {
+		return errors.New("Empty url")
+	}
+
+	req, err := http.NewRequest("PATCH", url, strings.NewReader(string(data)))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set(httpHeaderContentType, httpHeaderJSON)
+	req.SetBasicAuth(ac.config.Username, ac.config.Password)
+	resp, err := ac.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusCreated &&
+		resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return errors.New(resp.Status)
+	}
+	return nil
+}
+
 //SwitchAccount : Switch account
 func (ac *APIClient) SwitchAccount(username, password string) {
 	if len(strings.TrimSpace(username)) == 0 ||

--- a/src/harbor-api-testing/lib/scanner.go
+++ b/src/harbor-api-testing/lib/scanner.go
@@ -1,0 +1,67 @@
+package lib
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/vmware/harbor-boshrelease/src/harbor-api-testing/client"
+	"strings"
+)
+
+type ScannerUtil struct {
+	rootURI       string
+	testingClient *client.APIClient
+}
+
+type Scanner struct {
+	UUID      string `json:"uuid"`
+	Name      string `json:"name"`
+	IsDefault bool   `json:"is_default"`
+}
+
+func NewScannerUtil(rootURI string, httpClient *client.APIClient) *ScannerUtil {
+	if len(strings.TrimSpace(rootURI)) == 0 || httpClient == nil {
+		return nil
+	}
+
+	return &ScannerUtil{
+		rootURI:       rootURI,
+		testingClient: httpClient,
+	}
+}
+
+func (su *ScannerUtil) GetScanners() ([]Scanner, error) {
+	url := fmt.Sprintf("%v/api/v2.0/scanners", su.rootURI)
+	data, err := su.testingClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	var scanners []Scanner
+	if err = json.Unmarshal(data, &scanners); err != nil {
+		return nil, err
+	}
+	return scanners, nil
+}
+
+func (su *ScannerUtil) SetDefaultScannerToClair() error {
+	scanners, err := su.GetScanners()
+	if err != nil {
+		return err
+	}
+	var clairUUID string
+	for _, s := range scanners {
+		if strings.EqualFold(s.Name, "clair") {
+			clairUUID = s.UUID
+		}
+	}
+	if len(clairUUID) == 0 {
+		return errors.New("clair scanner is not registered!")
+	}
+	return su.SetDefaultScanner(clairUUID)
+}
+
+func (su *ScannerUtil) SetDefaultScanner(uuid string) error {
+	url := fmt.Sprintf("%v/api/v2.0/scanners/%v", su.rootURI, uuid)
+	payload := `{"is_default":true}`
+	return su.testingClient.Patch(url, []byte(payload))
+}

--- a/src/harbor-api-testing/tests/suites/suite01/suite.go
+++ b/src/harbor-api-testing/tests/suites/suite01/suite.go
@@ -31,6 +31,11 @@ type ConcourseCiSuite01 struct {
 func (ccs *ConcourseCiSuite01) Run(onEnvironment *envs.Environment) *lib.Report {
 	report := &lib.Report{}
 
+	scanner := lib.NewScannerUtil(onEnvironment.RootURI(), onEnvironment.HTTPClient)
+	if err := scanner.SetDefaultScannerToClair(); err != nil {
+		report.Failed("SetDefaultScannerToClair ", err)
+	}
+
 	//s0
 	sys := lib.NewSystemUtil(onEnvironment.RootURI(), onEnvironment.Hostname, onEnvironment.HTTPClient)
 	if err := sys.GetSystemInfo(); err != nil {


### PR DESCRIPTION
Because of the known issue 12687: Default scanner should not be changed when upgrade from Harbor 1.9.x to 2.x, set the default scanner to clair before testing.