### PR TITLE
Add config-utils to handle the post-start script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+SHELL := /bin/bash
+BUILDPATH=$(CURDIR)
+UTILS_PATH=/harbor-boshrelease/src/utils
+UTILS_BIN_PATH=/harbor-boshrelease/make/config-utils
+SMOKE_TEST_PATH=/harbor-boshrelease/src/harbor-api-testing
+SMOKETEST_BIN_PATH=/harbor-boshrelease/make/smoke_test
+
+# docker parameters
+DOCKERCMD=$(shell which docker)
+
+GOBUILDPATHINCONTAINER=/harbor-boshrelease
+GOBUILDIMAGE=golang:1.14.7
+
+compile_smoke_test:
+	@echo "compiling binary for smoke_test..."
+	@echo $(GOBUILDPATHINCONTAINER)
+	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATHINCONTAINER) -w $(SMOKE_TEST_PATH) $(GOBUILDIMAGE) go build -o $(SMOKETEST_BIN_PATH)
+	@echo "Done."
+
+compile_config_utils:
+	@echo "compiling binary for config_utils..."
+	@echo $(GOBUILDPATHINCONTAINER)
+	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATHINCONTAINER) -w $(UTILS_PATH) $(GOBUILDIMAGE) go build -o $(UTILS_BIN_PATH)
+	@echo "Done."
+
+all: compile_smoke_test compile_config_utils

--- a/jobs/harbor/spec
+++ b/jobs/harbor/spec
@@ -68,9 +68,10 @@ properties:
   customize_crt:
     description: "Determine whether or not to generate certificate for the registry's token. If the value is on, the prepare script creates new root cert and private key for generating token to access the registry. If the value is off the default key/cert will be used. This flag also controls the creation of the notary signer's cert."
     default: "on"
-
   admin_password:
     description: "The initial password of Harbor admin, only works for the first time when Harbor starts"
+  admin_password_for_smoketest:
+    description: "The admin password for smoke test"
   auth_mode:
     description: "By default the auth mode is db_auth, i.e. the credentials are stored in a local database. Set it to ldap_auth if you want to verify a user's credentials against an LDAP server."
     default: "db_auth"

--- a/jobs/harbor/templates/bin/post-start.erb.sh
+++ b/jobs/harbor/templates/bin/post-start.erb.sh
@@ -23,32 +23,13 @@ waitForDBReady() {
     set -e
 }
 
-changeUserConfigSetting() {
-    key=$1
-    value=$2
-    $DOCKER_CMD exec harbor-db psql -U postgres -d registry -c "insert into properties (k, v) values ('$key', '$value') on conflict (k) do update set v = '$value';"
-}
-
 waitForDBReady
 
-changeUserConfigSetting auth_mode <%= p("auth_mode") %>
-
 <%- if p("auth_mode") == "uaa_auth" %>
-
-
 <%- if p("uaa.is_saml_backend") == true %>
-changeUserConfigSetting auth_mode oidc_auth
-changeUserConfigSetting oidc_name uaa
-changeUserConfigSetting oidc_endpoint <%= p("uaa.url").downcase %>/oauth/token
-changeUserConfigSetting oidc_client_id <%= p("uaa.client_id") %>
-changeUserConfigSetting oidc_client_secret <%= p("uaa.client_secret") %>
-changeUserConfigSetting oidc_scope <%= p("uaa.oidc_scope") %>
-changeUserConfigSetting oidc_verify_cert false
+$CONFIG_CMD -config-oidc -harbor-server https://<%= p("hostname") %> -password '<%= p("admin_password_for_smoketest") %>' -uaa-server <%= p("uaa.url") %>
 <%- else %>
-changeUserConfigSetting uaa_endpoint <%= p("uaa.url").downcase %>
-changeUserConfigSetting uaa_client_id <%= p("uaa.client_id") %>
-changeUserConfigSetting uaa_client_secret <%= p("uaa.client_secret") %>
-changeUserConfigSetting uaa_verify_cert <%= p("uaa.verify_cert") %>
+$CONFIG_CMD -config-uaa -harbor-server https://<%= p("hostname") %> -password '<%= p("admin_password_for_smoketest") %>' -uaa-server  <%= p("uaa.url") %> -verify-cert
 <%- end %>
 
 <%- end %>

--- a/jobs/harbor/templates/bin/uaa.erb.sh
+++ b/jobs/harbor/templates/bin/uaa.erb.sh
@@ -9,6 +9,7 @@ register_harbor_uaa_client() {
 
   #Start to register Harbor UAA client
   handle_harbor_uaa_client \
+    register \
     $UAA_VERIFY_CERT \
     $UAA_CA_FILE \
     $UAA_SERVER_ADDRESS \

--- a/jobs/harbor/templates/config/uaa.json.erb
+++ b/jobs/harbor/templates/config/uaa.json.erb
@@ -8,7 +8,6 @@
     "authorized_grant_types": ["client_credentials", "password", "authorization_code"],
     "redirect_uri": ["<%= p('ui_url_protocol') %>://<%= p('hostname', spec.ip) %>", "<%= p('ui_url_protocol') %>://<%= p('hostname', spec.ip) %>/c/oidc/callback"],
     "authorities": ["openid", "clients.read", "clients.secret", "uaa.resource", "scim.read", "scim.write"],
-    "token_salt": "<%= Array.new(8){range.sample}.join %>",
     "autoapprove": true,
     "name": "Harbor UAA Client"
 }
@@ -22,7 +21,6 @@
     "authorized_grant_types": ["client_credentials", "password"],
     "redirect_uri": ["<%= p('ui_url_protocol') %>://<%= p('hostname', spec.ip) %>, <%= p('ui_url_protocol') %>://<%= p('hostname', spec.ip) %>/*"],
     "authorities": ["openid", "clients.read", "clients.secret", "uaa.resource", "scim.read", "scim.write"],
-    "token_salt": "<%= Array.new(8){range.sample}.join %>",
     "autoapprove": true,
     "allowedproviders": ["uaa", "ldap"],
     "name": "Harbor UAA Client"

--- a/jobs/uaa-deregistration/templates/run.sh
+++ b/jobs/uaa-deregistration/templates/run.sh
@@ -31,6 +31,7 @@ UAA_ADMIN_CLIENT_SECRET='<%= link('harbor_uaa_reference').p('uaa.admin.client_se
 
 #Start to unregister Harbor UAA client
 handle_harbor_uaa_client \
+  unregister \
   $UAA_VERIFY_CERT \
   $UAA_CA_FILE \
   $UAA_SERVER_ADDRESS \

--- a/packages/harbor-common/packaging
+++ b/packages/harbor-common/packaging
@@ -2,3 +2,4 @@ set -e
 
 cp -a harbor-common/* ${BOSH_INSTALL_TARGET}
 chmod +x ${BOSH_INSTALL_TARGET}/*.sh
+chmod +x ${BOSH_INSTALL_TARGET}/config-utils

--- a/packages/harbor-common/spec
+++ b/packages/harbor-common/spec
@@ -10,3 +10,4 @@ files:
 - harbor-common/fix-notary.sql
 - harbor-common/harbor-backup.sh
 - harbor-common/harbor-restore.sh
+- harbor-common/config-utils

--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -11,6 +11,7 @@ DOCKER_DAEMON_SOCK=${DOCKER_RUN_DIR}/dockerd.sock
 DOCKER_HOST="unix://$DOCKER_DAEMON_SOCK"
 DOCKER_CMD="${DOCKER_PACKAGE_DIR}/bin/docker -H $DOCKER_HOST"
 PYTHON_CMD="${PACKAGE_DIR}/python/python2.7/bin/python"
+CONFIG_CMD="${PACKAGE_DIR}/harbor-common/config-utils"
 
 log() {
   echo [`date`] $*

--- a/src/utils/client.go
+++ b/src/utils/client.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// UAAProfile - uaa config info
+type UAAProfile struct {
+	Scope                []string `json:"scope"`
+	ClientID             string   `json:"client_id"`
+	ClientSecret         string   `json:"client_secret"`
+	ResourceIds          []string `json:"resource_ids"`
+	AuthorizedGrantTypes []string `json:"authorized_grant_types"`
+	RedirectURI          []string `json:"redirect_uri"`
+	Authorities          []string `json:"authorities"`
+	TokenSalt            string   `json:"token_salt"`
+	Autoapprove          bool     `json:"autoapprove"`
+	Name                 string   `json:"name"`
+	Allowedproviders     []string `json:"allowedproviders,omitempty"`
+}
+
+var trace = false
+
+// Trace - print trace info when verbose is enabled
+func Trace(info interface{}) {
+	if trace {
+		fmt.Println(info)
+	}
+}
+
+// ConfigClient - config client
+type ConfigClient struct {
+	client    *http.Client
+	harborUrl string
+	username  string
+	password  string
+}
+
+func newConfigClient(client *http.Client, harborUrl string, username string, password string) *ConfigClient {
+	return &ConfigClient{client: client, harborUrl: harborUrl, username: username, password: password}
+}
+
+func main() {
+
+	// Usage:
+	// Print the uaa configure json with token_salt:
+	// utils --show-uaa --uaa-json /data/secret/keys/uaa.json
+	// Configure the uaa setting in Harbor with current uaa.json
+	// utils -config-uaa -harbor-server https://10.186.197.207 -password Harbor12345 -uaa-server https://api.pks.local  -verify-cert
+	// Configure the oidc setting in Harbor with current uaa.json
+	// utils -config-oidc -harbor-server https://10.186.197.207 -password Harbor12345 -uaa-server https://api.pks.local  -verify-cert
+
+	isShowUAA := flag.Bool("show-uaa", false, "Display UAA json which add token salt info")
+	trustedCA := flag.String("trusted-ca", "/var/vcap/jobs/harbor/config/ca.crt", "Trusted certificate")
+	insecure := flag.Bool("insecure", false, "insecure")
+	isConfigUAA := flag.Bool("config-uaa", false, "Config UAA")
+	isConfigOIDC := flag.Bool("config-oidc", false, "Config OIDC")
+	harborServerUrl := flag.String("harbor-server", "", "Harbor server url to configure")
+	uaaJsonPath := flag.String("uaa-json", "/var/vcap/jobs/harbor/config/uaa.json", "uaa json file path")
+	password := flag.String("password", "", "password to configure harbor")
+	tokenSaltFile := flag.String("salt-file", "/data/secret/keys/uaa_token_salt", "uaa token salt file")
+	uaaServer := flag.String("uaa-server", "", "UAA server to authenticate")
+	verifyCert := flag.Bool("verify-cert", false, "Verify cert")
+	// verbose is used for debugging, dump all information to console
+	verbose := flag.Bool("verbose", false, "Display verbose info")
+
+	flag.Parse()
+
+	trace = *verbose
+
+	if *isShowUAA {
+		uaaProf, err := parseJsonFile(*uaaJsonPath)
+		checkError(err)
+		uaaProf.TokenSalt = readTokenSalt(*tokenSaltFile)
+		Trace("token salt is changed to " + uaaProf.TokenSalt)
+		content, err := json.Marshal(uaaProf)
+		checkError(err)
+		fmt.Print(string(content))
+		os.Exit(0)
+	}
+
+	checkParameter(harborServerUrl, password, uaaServer)
+	client := createHttpClient(*trustedCA, *insecure)
+	c := newConfigClient(client, *harborServerUrl, "admin", *password)
+	uaaProf, err := parseJsonFile(*uaaJsonPath)
+	checkError(err)
+	if *isConfigOIDC {
+		err = c.configOIDC(uaaProf, *uaaServer, *verifyCert)
+	}
+
+	if *isConfigUAA {
+		err = c.configUAA(uaaProf, *uaaServer, *verifyCert)
+
+	}
+	checkError(err)
+	os.Exit(0)
+}
+
+func checkParameter(harborServerUrl, password, uaaServer *string) {
+	if len(*harborServerUrl) == 0 {
+		Trace("Please provide server url to configure")
+		os.Exit(1)
+	}
+	if len(*password) == 0 {
+		Trace("need to provide admin password to configure")
+		os.Exit(1)
+	}
+	if len(*uaaServer) == 0 {
+		Trace("Need to provide the uaa server info")
+		os.Exit(1)
+	}
+}
+
+func checkError(err error) {
+	if err != nil {
+		Trace(err)
+		os.Exit(1)
+	}
+}
+
+func parseJsonFile(jsonPath string) (*UAAProfile, error) {
+	var profile UAAProfile
+	content, err := ioutil.ReadFile(jsonPath)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(content, &profile)
+	if err != nil {
+		return nil, err
+	}
+	return &profile, nil
+}
+
+func readTokenSalt(tokenSaltFile string) string {
+	var token string
+	_, err := os.Stat(tokenSaltFile)
+	if os.IsNotExist(err) {
+		token, err = tokenSalt(tokenSaltFile)
+		checkError(err)
+		return token
+	}
+	content, err := ioutil.ReadFile(tokenSaltFile)
+	checkError(err)
+	token = string(content)
+	if strings.TrimSpace(token) == "" {
+		token, err = tokenSalt(tokenSaltFile)
+		checkError(err)
+	}
+	return token
+}
+
+func tokenSalt(tokenSaltFile string) (string, error) {
+	token := randString(8)
+	err := ioutil.WriteFile(tokenSaltFile, []byte(token), 0644)
+	if err != nil {
+		return "", nil
+	}
+	return token, nil
+}
+
+func stringWithCharset(length int, charset string) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func randString(length int) string {
+	return stringWithCharset(length, charset)
+}
+
+func createHttpClient(caCertFile string, insecure bool) *http.Client {
+	// Get the SystemCertPool, continue with an empty pool on error
+	rootCAs, _ := x509.SystemCertPool()
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+	// Read in the cert file
+	if !insecure {
+		certs, err := ioutil.ReadFile(caCertFile)
+		if os.IsNotExist(err) {
+			Trace(fmt.Sprintf("The cert file is not found %v, ignore it", caCertFile))
+		} else {
+			// Append our cert to the system pool
+			if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
+				Trace("No certs appended, using system certs only")
+			}
+		}
+	}
+
+	// Trust the augmented cert pool in our client
+	config := &tls.Config{
+		InsecureSkipVerify: insecure,
+		RootCAs:            rootCAs,
+	}
+	tr := &http.Transport{TLSClientConfig: config}
+	return &http.Client{Transport: tr}
+}
+
+func (c *ConfigClient) configHarborWithSetting(setting map[string]interface{}) error {
+	url := c.harborUrl + "/api/v2.0/configurations"
+	method := "PUT"
+	payload, err := json.Marshal(setting)
+	checkError(err)
+	req, err := http.NewRequest(method, url, bytes.NewReader(payload))
+	checkError(err)
+	req.SetBasicAuth(c.username, c.password)
+	req.Header.Add("Content-Type", "application/json")
+	res, err := c.client.Do(req)
+	checkError(err)
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+	checkError(err)
+	Trace(fmt.Sprintf("Response code %v\n", res.StatusCode))
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to send request to %v, response code %v", url, res.StatusCode)
+	}
+	Trace("request content is " + string(body) + "\n")
+	return nil
+}
+
+func (c *ConfigClient) configOIDC(setting *UAAProfile, uaaUrl string, verifyCert bool) error {
+	s := map[string]interface{}{
+		"auth_mode":          "oidc_auth",
+		"oidc_endpoint":      strings.ToLower(uaaUrl) + "/oauth/token",
+		"oidc_name":          "uaa",
+		"oidc_client_id":     setting.ClientID,
+		"oidc_client_secret": setting.ClientSecret,
+		"oidc_scope":         strings.Join(setting.Scope, ","),
+		"oidc_verify_cert":   verifyCert,
+	}
+
+	return c.configHarborWithSetting(s)
+}
+
+func (c *ConfigClient) configUAA(setting *UAAProfile, uaaUrl string, verifyCert bool) error {
+	s := map[string]interface{}{
+		"auth_mode":         "uaa_auth",
+		"uaa_endpoint":      strings.ToLower(uaaUrl),
+		"uaa_client_id":     setting.ClientID,
+		"uaa_client_secret": setting.ClientSecret,
+		"uaa_verify_cert":   verifyCert,
+	}
+	return c.configHarborWithSetting(s)
+}

--- a/src/utils/client_test.go
+++ b/src/utils/client_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestConfigHarborWithSetting(t *testing.T) {
+	type args struct {
+		harborUrl string
+		setting   map[string]interface{}
+		username  string
+		password  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"test normal", args{"https://10.186.197.207", map[string]interface{}{"auth_mode": "ldap_auth"}, "admin", "Harbor12345"}, false},
+		{"test normal", args{"https://10.186.197.207", map[string]interface{}{"auth_mode": "ldap_auth"}, "admin", "1234"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := createHttpClient("", true)
+			c := newConfigClient(client, tt.args.harborUrl, "admin", tt.args.password)
+			if err := c.configHarborWithSetting(tt.args.setting); (err != nil) != tt.wantErr {
+				t.Errorf("configHarborWithSetting() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes PKS-816 issue: docker login with secret fails without user logging into Harbor UI then use cli secret from user profile.
Avoid delete and register new uaa client when the uaa client already exist.
Store token_salt in /data/secret/keys/uaa_token_salt and reuse it.