### PR TITLE
Avoid pull telegraph and wavefront proxy image from dockerhub

### DIFF
--- a/jobs/wavefront/templates/config/docker-compose.yml.erb
+++ b/jobs/wavefront/templates/config/docker-compose.yml.erb
@@ -1,24 +1,26 @@
 version: '3.7'
 services:
-    telegraf:
-       image: telegraf:1.14
-       command: ["telegraf", "--config", "/telegraf.config"]
-       volumes:
-           - "/:/hostfs:ro"
-           - "./telegraf.config:/telegraf.config"
-           - "/var/log/harbor:/harbor_log"
-       environment:
-           - HOST_MOUNT_PREFIX=/hostfs
-           - HOST_PROC=/hostfs/proc
-    wavefront-proxy:
-        image: wavefronthq/proxy:5.7
-        environment:
-            - WAVEFRONT_URL=<%= p("wavefront_url") %> 
-            - WAVEFRONT_TOKEN=<%= p("wavefront_token") %> 
-            - JAVA_HEAP_USAGE=512m
-        volumes:
-            - "./proxy-log4j2.xml:/etc/wavefront/wavefront-proxy/log4j2.xml"
-            - "/var/log/harbor:/harbor_log"
-        ports:
-            - "2878:2878"
-            - "4242:4242"
+  telegraf:
+    image: telegraf:1.14
+    pull_policy: never
+    command: ["telegraf", "--config", "/telegraf.config"]
+    volumes:
+      - "/:/hostfs:ro"
+      - "./telegraf.config:/telegraf.config"
+      - "/var/log/harbor:/harbor_log"
+    environment:
+      - HOST_MOUNT_PREFIX=/hostfs
+      - HOST_PROC=/hostfs/proc
+  wavefront-proxy:
+    image: wavefronthq/proxy:5.7
+    pull_policy: never
+    environment:
+      - WAVEFRONT_URL=<%= p("wavefront_url") %> 
+      - WAVEFRONT_TOKEN=<%= p("wavefront_token") %> 
+      - JAVA_HEAP_USAGE=512m
+    volumes:
+      - "./proxy-log4j2.xml:/etc/wavefront/wavefront-proxy/log4j2.xml"
+      - "/var/log/harbor:/harbor_log"
+    ports:
+      - "2878:2878"
+      - "4242:4242"


### PR DESCRIPTION
Sometimes the docker-compose might pull image from dockerhub and it might be rate limit by dockerhub
To avoid this issue, set pull_policy: never in docker-compose.yaml